### PR TITLE
gulp template update

### DIFF
--- a/server/utils/templates/gulpTemplate.ejs
+++ b/server/utils/templates/gulpTemplate.ejs
@@ -28,18 +28,20 @@ function buildScript(file, watch) {
   //watchify if watch set to true. otherwise browserify once
   var bundler = watch ? watchify(browserify(props)) : browserify(props);
 
-  function rebundle(){
+  function rebundle(updateStart){
     var stream = bundler.bundle();
     return stream
       .on('error', handleErrors)
       .pipe(source('bundle.js'))
-      .pipe(gulp.dest('./build/'));
+      .pipe(gulp.dest('./build/'))
+      .on('finish', ()=>{
+        console.log('Updated!', (Date.now() - updateStart) + 'ms');
+      })
   }
 
   bundler.on('update', function() {
     var updateStart = Date.now();
-    rebundle();
-    console.log('Updated!', (Date.now() - updateStart) + 'ms');
+    rebundle(updateStart);
   })
 
   // run it once the first time buildScript is called


### PR DESCRIPTION
gulp file was logging to console that it was updating in around ~10ms. In
reality what was happening was it was asynchronously skipping
rebundle() and logging the elapsed time in a few milliseconds - processing time was more like 4 seconds.

This fix properly logs ‘Updated’ w/ real-time spent updating - via
.on(‘finish’, callback) listener .
